### PR TITLE
Feat: kakao 소셜 로그인 및 sms 인증 기능 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -33,16 +33,19 @@ dependencies {
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
-    //dotenv
+    // dotenv
     implementation("io.github.cdimascio:dotenv-java:2.2.0")
 
-    //jjwt
+    // jjwt
     implementation ("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly ("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly ("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
-    //webflux
+    // webflux
     implementation ("org.springframework.boot:spring-boot-starter-webflux")
+
+    // coolSMS
+    implementation ("net.nurigo:sdk:4.3.0")
 
     // 테스트
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -41,6 +41,9 @@ dependencies {
     runtimeOnly ("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly ("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+    //webflux
+    implementation ("org.springframework.boot:spring-boot-starter-webflux")
+
     // 테스트
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 

--- a/backend/src/main/java/com/silverbridge/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/silverbridge/backend/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
 //                                "/api/calendar/**"      // 캘린더 API 허용
 //                        ).permitAll()
 //                        .anyRequest().authenticated()
+								.requestMatchers("/api/users/social/kakao", "/api/users/social/register-final").permitAll()
                                 .anyRequest().permitAll()
                 )
                 .addFilterBefore(

--- a/backend/src/main/java/com/silverbridge/backend/config/WebClientConfig.java
+++ b/backend/src/main/java/com/silverbridge/backend/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.silverbridge.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+	@Bean
+	public WebClient webClient() {
+		return WebClient.builder().build();
+	}
+}

--- a/backend/src/main/java/com/silverbridge/backend/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/silverbridge/backend/controller/KakaoAuthController.java
@@ -1,0 +1,61 @@
+package com.silverbridge.backend.controller;
+
+import com.silverbridge.backend.dto.KakaoProfile;
+import com.silverbridge.backend.dto.TokenDto;
+import com.silverbridge.backend.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@RestController
+@RequestMapping("/api/users/social")
+@RequiredArgsConstructor
+public class KakaoAuthController {
+
+	private final UserService userService;
+
+	/*
+	 * 카카오 로그인 콜백 or 프론트에서 Access Token 전달받는 엔드포인트
+	 * 프론트엔드가 카카오 access_token을 서버에 넘겨주면
+	 * 서버는 카카오 API로 사용자 정보 조회 후 socialLoginOrJoin() 호출
+	 */
+	@PostMapping("/kakao")
+	public ResponseEntity<?> kakaoLogin(@RequestParam("accessToken") String kakaoAccessToken) {
+		try {
+			// 프론트에서 access_token을 받아서 카카오 사용자 정보 조회
+			KakaoProfile kakaoProfile = getKakaoUserProfile(kakaoAccessToken);
+
+			// UserService로 로그인 or 회원가입 처리
+			TokenDto tokenResponse = userService.socialLoginOrJoin(kakaoProfile);
+
+			return ResponseEntity.ok(tokenResponse);
+
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+					.body("카카오 로그인 실패: " + e.getMessage());
+		}
+	}
+
+	/*
+	 *  카카오 API 호출, (kapi.kakao.com/v2/user/me)
+	 *  KakaoProfile DTO로 파싱
+	 */
+	private KakaoProfile getKakaoUserProfile(String kakaoAccessToken) {
+		try {
+			return WebClient.create("https://kapi.kakao.com")
+					.get()
+					.uri("/v2/user/me")
+					.header("Authorization", "Bearer " + kakaoAccessToken)
+					.retrieve()
+					.bodyToMono(KakaoProfile.class)
+					.block();
+		} catch (WebClientResponseException e) {
+			throw new RuntimeException("카카오 사용자 정보 요청 실패: " + e.getResponseBodyAsString(), e);
+		} catch (Exception e) {
+			throw new RuntimeException("카카오 사용자 정보 요청 중 오류 발생: " + e.getMessage(), e);
+		}
+	}
+}

--- a/backend/src/main/java/com/silverbridge/backend/controller/SmsController.java
+++ b/backend/src/main/java/com/silverbridge/backend/controller/SmsController.java
@@ -1,0 +1,61 @@
+package com.silverbridge.backend.controller;
+
+import com.silverbridge.backend.service.SmsService;
+import com.silverbridge.backend.service.SmsVerificationManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.concurrent.*;
+
+@RestController
+@RequestMapping("/api/sms")
+@RequiredArgsConstructor
+public class SmsController {
+
+	private final SmsService smsService;
+	private final SmsVerificationManager verificationManager;
+
+	private final Map<String, String> verificationStorage = new ConcurrentHashMap<>();
+	private final Map<String, ScheduledFuture<?>> expirationTasks = new ConcurrentHashMap<>();
+	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+	@PostMapping("/send")
+	public ResponseEntity<?> sendCode(@RequestParam String phoneNumber) {
+		String code = smsService.sendVerificationCode(phoneNumber);
+
+		verificationStorage.put(phoneNumber, code);
+		if (expirationTasks.containsKey(phoneNumber))
+			expirationTasks.get(phoneNumber).cancel(true);
+
+		ScheduledFuture<?> expirationTask = scheduler.schedule(() -> {
+			verificationStorage.remove(phoneNumber);
+			expirationTasks.remove(phoneNumber);
+			System.out.println("인증번호 만료됨: " + phoneNumber);
+		}, 5, TimeUnit.MINUTES);
+
+		expirationTasks.put(phoneNumber, expirationTask);
+		return ResponseEntity.ok("인증번호가 발송되었습니다. (유효시간: 5분)");
+	}
+
+	@PostMapping("/verify")
+	public ResponseEntity<?> verifyCode(@RequestParam String phoneNumber, @RequestParam String code) {
+		String storedCode = verificationStorage.get(phoneNumber);
+
+		if (storedCode != null && storedCode.equals(code)) {
+			verificationStorage.remove(phoneNumber);
+			if (expirationTasks.containsKey(phoneNumber)) {
+				expirationTasks.get(phoneNumber).cancel(true);
+				expirationTasks.remove(phoneNumber);
+			}
+
+			// 인증 성공 시 verifiedNumbers에 등록
+			verificationManager.markVerified(phoneNumber);
+			return ResponseEntity.ok("인증 성공");
+		} else {
+			return ResponseEntity.badRequest().body("인증번호가 일치하지 않거나 만료되었습니다.");
+		}
+	}
+}
+

--- a/backend/src/main/java/com/silverbridge/backend/controller/SocialInfoController.java
+++ b/backend/src/main/java/com/silverbridge/backend/controller/SocialInfoController.java
@@ -1,0 +1,53 @@
+package com.silverbridge.backend.controller;
+
+import com.silverbridge.backend.dto.FinalRegisterRequest;
+import com.silverbridge.backend.dto.TokenDto;
+import com.silverbridge.backend.jwt.JwtTokenProvider;
+import com.silverbridge.backend.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/users/social")
+@RequiredArgsConstructor
+public class SocialInfoController {
+
+	private final UserService userService;
+	private final JwtTokenProvider jwtTokenProvider; // 임시 토큰 검증용
+
+	// 최종 회원가입 및 본 토큰 발급 API
+	@PostMapping("/register-final")
+	public ResponseEntity<?> finalRegister(
+			@RequestHeader("Authorization") String tempTokenHeader,
+			@Valid @RequestBody FinalRegisterRequest request
+	) {
+		try {
+			// 임시 토큰에서 kakaoId 추출 및 유효성 검증
+			Long kakaoId = jwtTokenProvider.getKakaoIdFromTempToken(tempTokenHeader);
+
+			// UserService에서 최종 DB 저장 및 본 토큰 발급
+			TokenDto finalToken = userService.completeSocialRegistration(kakaoId, request);
+
+			// 본 토큰을 헤더에 담아 응답
+			HttpHeaders headers = new HttpHeaders();
+			headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + finalToken.getAccessToken());
+			headers.add("Refresh-Token", finalToken.getRefreshToken());
+
+			return ResponseEntity.ok()
+					.headers(headers)
+					.body(Map.of("message", "회원가입 및 로그인 성공"));
+
+		} catch (IllegalArgumentException e) {
+			return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED); // 401 UNAUTHORIZED
+		} catch (Exception e) {
+			// 기타 서버 오류
+			return new ResponseEntity<>("서버 오류가 발생했습니다: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+}

--- a/backend/src/main/java/com/silverbridge/backend/controller/UserController.java
+++ b/backend/src/main/java/com/silverbridge/backend/controller/UserController.java
@@ -58,14 +58,14 @@ public class UserController {
         }
     }
 
-		// 로그아웃
-	  @PostMapping("/logout")
-		public ResponseEntity<String> logout(@RequestBody LogoutRequest request) {
-			try {
-				userService.logout(request.getRefreshToken()); // DB에 저장된 리프레시 토큰 삭제
-				return ResponseEntity.ok("로그아웃 성공"); // 로그아웃 성공 응답 => 프론트엔드는 로컬에 저장된 토큰을 삭제해야 함
-			} catch (IllegalArgumentException ex) {
-				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage()); // 유효하지 않은 토큰인 경우 처리
-			}
+	// 로그아웃
+	@PostMapping("/logout")
+	public ResponseEntity<String> logout(@RequestBody LogoutRequest request) {
+		try {
+			userService.logout(request.getRefreshToken()); // DB에 저장된 리프레시 토큰 삭제
+			return ResponseEntity.ok("로그아웃 성공"); // 로그아웃 성공 응답 => 프론트엔드는 로컬에 저장된 토큰을 삭제해야 함
+		} catch (IllegalArgumentException ex) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage()); // 유효하지 않은 토큰인 경우 처리
 		}
+	}
 }

--- a/backend/src/main/java/com/silverbridge/backend/dto/FinalRegisterRequest.java
+++ b/backend/src/main/java/com/silverbridge/backend/dto/FinalRegisterRequest.java
@@ -1,0 +1,33 @@
+package com.silverbridge.backend.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+// 소셜 가입시 필수 추가 정보를 받기 위한 DTO (입력폼)
+@Getter
+@Setter
+public class FinalRegisterRequest {
+
+	@NotBlank(message = "이름은 필수 입력 값입니다.")
+	@Pattern(regexp = "^[가-힣]+$", message = "이름은 한글만 가능합니다.")
+	private String name;
+
+	@Pattern(regexp = "^010-[0-9]{4}-[0-9]{4}$", message = "전화번호 양식은 XXX-XXXX-XXXX로 입력해야 합니다.")
+	private String phoneNumber;
+
+	@Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "잘못된 생년월일 양식입니다.")
+	@NotBlank(message = "생년월일은 필수 입력 값입니다.")
+	private String birth;
+
+	@NotNull(message = "성별을 체크하셔야 합니다.")
+	private Boolean gender;
+
+	@NotBlank(message = "지역을 체크하셔야 합니다.")
+	private String region;
+
+	@NotBlank(message = "글자 크기는 필수 입력 값입니다.")
+	private String textsize;
+}

--- a/backend/src/main/java/com/silverbridge/backend/dto/KakaoProfile.java
+++ b/backend/src/main/java/com/silverbridge/backend/dto/KakaoProfile.java
@@ -1,0 +1,24 @@
+package com.silverbridge.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+// 카카오 사용자 정보 응답을 위한 최상위 DTO
+@Getter
+@Setter
+public class KakaoProfile {
+
+	private Long id; // 카카오 고유 ID
+	private Properties properties; // 사용자 상세 정보가 포함된 중첩 객체
+
+	// 중첩 클래스: Properties (닉네임)
+	@Getter
+	@Setter
+	public static class Properties {
+		private String nickname;
+
+		@JsonProperty("profile_image")
+		private String profileImage;
+	}
+}

--- a/backend/src/main/java/com/silverbridge/backend/dto/KakaoTokenResponse.java
+++ b/backend/src/main/java/com/silverbridge/backend/dto/KakaoTokenResponse.java
@@ -1,0 +1,26 @@
+package com.silverbridge.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+// 카카오 토큰 서버 응답을 위한 DTO
+@Getter
+@Setter
+public class KakaoTokenResponse {
+
+	@JsonProperty("access_token")
+	private String accessToken;
+
+	@JsonProperty("token_type")
+	private String tokenType;
+
+	@JsonProperty("refresh_token")
+	private String refreshToken;
+
+	@JsonProperty("expires_in")
+	private Integer expiresIn;
+
+	@JsonProperty("refresh_token_expires_in")
+	private Integer refreshTokenExpiresIn;
+}

--- a/backend/src/main/java/com/silverbridge/backend/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/silverbridge/backend/handler/GlobalExceptionHandler.java
@@ -23,15 +23,26 @@ public class GlobalExceptionHandler {
         responseBody.put("code", 600); // 명세에 없는 예외는 600대 코드로 처리함
         responseBody.put("message", "유효성 검사 실패");
 
-        ex.getBindingResult().getAllErrors().forEach(error -> {
-            String fieldName = ((FieldError) error).getField();
-            String errorMessage = error.getDefaultMessage();
-            if (fieldName.equals("phoneNumber")) responseBody.put("code", 607);
-            else if (fieldName.equals("password")) responseBody.put("code", 601);
-            else if (fieldName.equals("name")) responseBody.put("code", 603);
-            else if (fieldName.equals("birth")) responseBody.put("code", 605);
-            else if (fieldName.equals("gender")) responseBody.put("code", 606);
-        });
+		Map<String, String> fieldErrors = new HashMap<>();
+
+		for (var error : ex.getBindingResult().getAllErrors()) {
+			String fieldName = ((FieldError) error).getField();
+			String errorMessage = error.getDefaultMessage();
+			fieldErrors.put(fieldName, errorMessage);
+
+			// 명세 기반 코드 매핑
+			switch (fieldName) {
+				case "phoneNumber" -> responseBody.put("code", 607);
+				case "password" -> responseBody.put("code", 601);
+				case "name" -> responseBody.put("code", 603);
+				case "birth" -> responseBody.put("code", 605);
+				case "gender" -> responseBody.put("code", 606);
+				default -> responseBody.put("code", 600);
+			}
+		}
+
+		// 필드별 상세 에러메시지 포함
+		responseBody.put("details", fieldErrors);
 
         return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
     }

--- a/backend/src/main/java/com/silverbridge/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/silverbridge/backend/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhoneNumber(String phoneNumber);
     boolean existsByPhoneNumber(String phoneNumber);
+	Optional<User> findByKakaoId(Long kakaoId);
 }

--- a/backend/src/main/java/com/silverbridge/backend/service/KakaoService.java
+++ b/backend/src/main/java/com/silverbridge/backend/service/KakaoService.java
@@ -1,0 +1,72 @@
+package com.silverbridge.backend.service;
+
+import com.silverbridge.backend.dto.KakaoTokenResponse;
+import com.silverbridge.backend.dto.KakaoProfile;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoService {
+
+	// application.yml 설정 값 주입
+	@Value("${kakao.client-id}") private String clientId;
+	@Value("${kakao.redirect-uri}") private String redirectUri;
+	@Value("${kakao.token-url}") private String tokenUrl;
+	@Value("${kakao.user-info-url}") private String userInfoUrl;
+
+	private final WebClient webClient; // WebClient 빈 주입 (Config 파일 필요)
+
+	// 1. 인가 코드를 카카오 액세스 토큰으로 교환
+	public String getKakaoAccessToken(String code) {
+
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("grant_type", "authorization_code");
+		body.add("client_id", clientId);
+		body.add("redirect_uri", redirectUri);
+		body.add("code", code);
+
+		KakaoTokenResponse tokenResponse = webClient.mutate()
+				.baseUrl(tokenUrl)
+				.build()
+				.post()
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.body(BodyInserters.fromFormData(body))
+				.retrieve()
+				.bodyToMono(KakaoTokenResponse.class)
+				.block(); // 동기적으로 처리 (실제 환경에서는 Mono/Flux 사용 권장)
+
+		if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+			throw new RuntimeException("카카오 토큰 발급에 실패했습니다.");
+		}
+
+		return tokenResponse.getAccessToken();
+	}
+
+	// 2. 카카오 토큰으로 사용자 정보 조회
+	public KakaoProfile getKakaoProfile(String kakaoAccessToken) {
+
+		KakaoProfile profile = webClient.mutate()
+				.baseUrl(userInfoUrl)
+				.build()
+				.get()
+				.header("Authorization", "Bearer " + kakaoAccessToken)
+				.retrieve()
+				.bodyToMono(KakaoProfile.class)
+				.block();
+
+		if (profile == null || profile.getId() == null) {
+			throw new RuntimeException("카카오 사용자 정보를 가져오는데 실패했습니다.");
+		}
+
+		return profile;
+	}
+}

--- a/backend/src/main/java/com/silverbridge/backend/service/SmsService.java
+++ b/backend/src/main/java/com/silverbridge/backend/service/SmsService.java
@@ -27,7 +27,7 @@ public class SmsService {
 	// 인증번호 전송 메서드
 	public String sendVerificationCode(String phoneNumber) {
 		String verificationCode = generateCode();
-		System.out.println("발송된 인증번호(test용): " + verificationCode);
+		// System.out.println("발송된 인증번호(test용): " + verificationCode); // TODO: 테스트 완료 후 삭제
 
 		Message message = new Message();
 		message.setFrom(senderNumber);

--- a/backend/src/main/java/com/silverbridge/backend/service/SmsService.java
+++ b/backend/src/main/java/com/silverbridge/backend/service/SmsService.java
@@ -1,0 +1,54 @@
+package com.silverbridge.backend.service;
+
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+public class SmsService {
+
+	private final DefaultMessageService messageService;
+
+	@Value("${sms.sender}")
+	private String senderNumber;
+
+	public SmsService(
+			@Value("${sms.api-key}") String apiKey,
+			@Value("${sms.api-secret}") String apiSecret) {
+		this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+	}
+
+	// 인증번호 전송 메서드
+	public String sendVerificationCode(String phoneNumber) {
+		String verificationCode = generateCode();
+		System.out.println("발송된 인증번호(test용): " + verificationCode);
+
+		Message message = new Message();
+		message.setFrom(senderNumber);
+		message.setTo(phoneNumber);
+		message.setText("[SilverBridge] 인증번호는 [" + verificationCode + "] 입니다.");
+
+		try {
+			SingleMessageSendingRequest request = new SingleMessageSendingRequest(message);
+			SingleMessageSentResponse response = messageService.sendOne(request);
+
+			System.out.println("CoolSMS 응답: " + response);
+		} catch (Exception e) {
+			throw new RuntimeException("문자 전송 실패: " + e.getMessage(), e);
+		}
+
+		return verificationCode;
+	}
+
+	private String generateCode() {
+		Random random = new Random();
+		int code = 100000 + random.nextInt(900000); // 6자리 숫자
+		return String.valueOf(code);
+	}
+}

--- a/backend/src/main/java/com/silverbridge/backend/service/SmsVerificationManager.java
+++ b/backend/src/main/java/com/silverbridge/backend/service/SmsVerificationManager.java
@@ -1,0 +1,28 @@
+package com.silverbridge.backend.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class SmsVerificationManager {
+
+	// 인증된 전화번호 목록
+	private final Map<String, Boolean> verifiedNumbers = new ConcurrentHashMap<>();
+
+	// 인증 성공 시 저장
+	public void markVerified(String phoneNumber) {
+		verifiedNumbers.put(phoneNumber, true);
+	}
+
+	// 인증 여부 확인
+	public boolean isVerified(String phoneNumber) {
+		return verifiedNumbers.getOrDefault(phoneNumber, false);
+	}
+
+	// 회원가입 완료 시 제거 (1회용)
+	public void consume(String phoneNumber) {
+		verifiedNumbers.remove(phoneNumber);
+	}
+}

--- a/backend/src/main/java/com/silverbridge/backend/service/UserService.java
+++ b/backend/src/main/java/com/silverbridge/backend/service/UserService.java
@@ -29,17 +29,25 @@ public class UserService {
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final SmsVerificationManager smsVerificationManager;
 
-	public UserService(UserRepository userRepository, RefreshTokenRepository refreshTokenRepository, PasswordEncoder passwordEncoder, JwtTokenProvider jwtTokenProvider) {
+	public UserService(UserRepository userRepository, RefreshTokenRepository refreshTokenRepository, PasswordEncoder passwordEncoder, JwtTokenProvider jwtTokenProvider, SmsVerificationManager smsVerificationManager) {
 		this.userRepository = userRepository;
 		this.refreshTokenRepository = refreshTokenRepository;
 		this.passwordEncoder = passwordEncoder;
 		this.jwtTokenProvider = jwtTokenProvider;
+		this.smsVerificationManager = smsVerificationManager;
 	}
 
 	// 회원가입 메서드
 	@Transactional
 	public void join(JoinRequest request) {
+		String phoneNumber = request.getPhoneNumber();
+
+		if (!smsVerificationManager.isVerified(phoneNumber)) {
+			throw new IllegalArgumentException("전화번호 인증이 완료되지 않았습니다.");
+		}
+
 		if (userRepository.existsByPhoneNumber(request.getPhoneNumber())) {
 			throw new IllegalArgumentException("이미 존재하는 전화번호입니다.");
 		}

--- a/backend/src/main/java/com/silverbridge/backend/service/UserService.java
+++ b/backend/src/main/java/com/silverbridge/backend/service/UserService.java
@@ -3,8 +3,10 @@ package com.silverbridge.backend.service;
 import com.silverbridge.backend.domain.RefreshToken;
 import com.silverbridge.backend.domain.User;
 import com.silverbridge.backend.dto.JoinRequest;
+import com.silverbridge.backend.dto.KakaoProfile;
 import com.silverbridge.backend.dto.TokenDto;
 import com.silverbridge.backend.jwt.JwtTokenProvider;
+import com.silverbridge.backend.dto.FinalRegisterRequest;
 import com.silverbridge.backend.repository.RefreshTokenRepository;
 import com.silverbridge.backend.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -13,55 +15,121 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDateTime;
 import java.util.Collections;
-import org.springframework.security.core.Authentication;
-
+import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @Service
 @Transactional(readOnly = true)
 public class UserService {
 
-    private final UserRepository userRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final JwtTokenProvider jwtTokenProvider;
+	private final UserRepository userRepository;
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtTokenProvider jwtTokenProvider;
 
-    public UserService(UserRepository userRepository, RefreshTokenRepository refreshTokenRepository, PasswordEncoder passwordEncoder, JwtTokenProvider jwtTokenProvider) {
-        this.userRepository = userRepository;
-        this.refreshTokenRepository = refreshTokenRepository;
-        this.passwordEncoder = passwordEncoder;
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
+	public UserService(UserRepository userRepository, RefreshTokenRepository refreshTokenRepository, PasswordEncoder passwordEncoder, JwtTokenProvider jwtTokenProvider) {
+		this.userRepository = userRepository;
+		this.refreshTokenRepository = refreshTokenRepository;
+		this.passwordEncoder = passwordEncoder;
+		this.jwtTokenProvider = jwtTokenProvider;
+	}
 
 	// 회원가입 메서드
-    @Transactional
-    public void join(JoinRequest request) {
-        if (userRepository.existsByPhoneNumber(request.getPhoneNumber())) {
-            throw new IllegalArgumentException("이미 존재하는 전화번호입니다.");
-        }
+	@Transactional
+	public void join(JoinRequest request) {
+		if (userRepository.existsByPhoneNumber(request.getPhoneNumber())) {
+			throw new IllegalArgumentException("이미 존재하는 전화번호입니다.");
+		}
 
-        User user = new User(
-                request.getName(),
+		User user = User.createGeneralUser(
+				request.getName(),
 				request.getPhoneNumber(),
-                passwordEncoder.encode(request.getPassword()),
-                request.getBirth(),
-                request.getGender(),
-                request.getSocial(),
-                request.getRegion(),
-                request.getTextsize()
-        );
-        userRepository.save(user);
-    }
+				passwordEncoder.encode(request.getPassword()),
+				request.getBirth(),
+				request.getGender(),
+				false,
+				request.getRegion(),
+				request.getTextsize()
+		);
+		userRepository.save(user);
+	}
+
+	// 카카오 소셜 로그인 및 회원가입 메서드
+	@Transactional(readOnly = true)
+	public TokenDto socialLoginOrJoin(KakaoProfile profile) {
+		Long kakaoId = profile.getId();
+
+		String nickname = Optional.ofNullable(profile.getProperties())
+				.map(KakaoProfile.Properties::getNickname)
+				.orElse("카카오 사용자"); // nickname이 null인 경우 fallback
+
+		// 기존 사용자: 즉시 로컬 JWT 발급 (로그인 성공)
+		Optional<User> existing = userRepository.findByKakaoId(profile.getId());
+		if (existing.isPresent()) {
+			log.info("기존 카카오 회원 로그인: {}", kakaoId);
+			return generateTokens(existing.get());
+		}
+
+		// 신규 사용자: 임시 토큰 발급
+		log.info("신규 카카오 사용자 임시 토큰 발급: ID {}", profile.getId());
+
+		// 회원가입 정보를 담은 임시 Access Token만 생성
+		// 토큰 Payload에 'kakaoId', 'role: GUEST' 등을 담아 클라이언트에 전달
+		String tempAccessToken = jwtTokenProvider.createTempAccessToken(profile.getId(), nickname);
+		return TokenDto.builder()
+				.grantType("Bearer")
+				.accessToken(tempAccessToken)
+				.refreshToken(null) // Refresh Token은 null로 반환
+				.build();
+	}
+
+	// 추가정보 입력 완료 후 최종 회원가입 + 통합 처리
+	@Transactional
+	public TokenDto completeSocialRegistration(Long kakaoId, FinalRegisterRequest request) {
+		// phoneNumber로 기존 일반회원 탐색
+		Optional<User> existingUser = userRepository.findByPhoneNumber(request.getPhoneNumber());
+
+		if (existingUser.isPresent()) {
+			User user = existingUser.get();
+
+			// 이미 다른 카카오 계정과 연결돼있다면 예외
+			if (user.getKakaoId() != null && !user.getKakaoId().equals(kakaoId)) {
+				throw new IllegalArgumentException("이미 다른 카카오 계정과 연결된 사용자입니다.");
+			}
+
+			// 기존 일반 회원 → 카카오 계정 연동
+			log.info("기존 일반 회원과 카카오 계정 통합: phoneNumber={}, kakaoId={}",
+					user.getPhoneNumber(), kakaoId);
+
+			user.linkKakaoAccount(kakaoId);
+			user.setSocial(true);
+			user.updateSocialInfo(request);
+			userRepository.save(user);
+
+			return generateTokens(user);
+		}
+
+		// 신규 User 생성
+		User newUser = User.createSocialUser(
+				kakaoId,
+				request.getName(),
+				request.getPhoneNumber(),
+				passwordEncoder.encode(UUID.randomUUID().toString()) // 더미 비번
+		);
+		newUser.updateSocialInfo(request); // 기타 정보 업데이트
+		userRepository.save(newUser); // DB 저장
+
+		// 정식 JWT 발급
+		log.info("신규 카카오 회원가입 완료: kakaoId={}, phoneNumber={}", kakaoId, request.getPhoneNumber());
+		return generateTokens(newUser);
+	}
 
     // 로그인 메서드는 토큰 생성만 담당
     @Transactional
-    public TokenDto generateTokens(String phoneNumber) {
-        User user = userRepository.findByPhoneNumber(phoneNumber)
-                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다."));
-
+    public TokenDto generateTokens(User user) {
         // JWT 토큰 생성을 위한 Authentication 객체 수동 생성
         Authentication authentication = new UsernamePasswordAuthenticationToken(user.getPhoneNumber(), user.getPassword(), Collections.emptyList());
 
@@ -88,11 +156,20 @@ public class UserService {
                 .build();
     }
 
-		// 로그아웃 메서드
-		@Transactional
-		public void logout(String refreshTokenValue) {
-				RefreshToken refreshToken = refreshTokenRepository.findByRefreshToken(refreshTokenValue)
-								.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.")); // 400 Bad Request
-				refreshTokenRepository.delete(refreshToken); // DB에서 리프레시 토큰 삭제
-		}
+	// 일반 로그인
+	@Transactional
+	public TokenDto generateTokens(String phoneNumber) {
+		User user = userRepository.findByPhoneNumber(phoneNumber)
+				.orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다."));
+
+		return generateTokens(user);
+	}
+
+	// 로그아웃 메서드
+	@Transactional
+	public void logout(String refreshTokenValue) {
+			RefreshToken refreshToken = refreshTokenRepository.findByRefreshToken(refreshTokenValue)
+							.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.")); // 400 Bad Request
+			refreshTokenRepository.delete(refreshToken); // DB에서 리프레시 토큰 삭제
+	}
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -34,3 +34,10 @@ logging:
 
 jwt:
   secret: ${JWT_SECRET_KEY}
+
+kakao:
+  client-id: ${KAKAO_REST_API_KEY}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: http://localhost:8080/api/users/oauth/kakao    # 프엔이 인가 코드를 보낼 엔드포인트
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,3 +41,8 @@ kakao:
   redirect-uri: http://localhost:8080/api/users/oauth/kakao    # 프엔이 인가 코드를 보낼 엔드포인트
   token-url: https://kauth.kakao.com/oauth/token
   user-info-url: https://kapi.kakao.com/v2/user/me
+
+sms:
+  api-key: ${SMS_API_KEY}
+  api-secret: ${SMS_API_SECRET}
+  sender: ${SMS_SENDER_NUMBER} # 발신자 번호


### PR DESCRIPTION
## ✨ Description

- Kakao 소셜 로그인 및 CoolSMS 기반 휴대폰 인증(SMS) 기능을 신규 추가했습니다.
- 일반 회원가입과 소셜 회원가입 모두 통합된 인증 구조로 개선했습니다.

## ✨ 주요 변경사항
### 1. 카카오 소셜 로그인 기능 추가

- /api/users/social/kakao
  - 카카오 Access Token 기반 사용자 프로필 조회 및 DB 연동
  - 기존 회원 → 즉시 JWT 발급
  - 신규 회원 → 임시 토큰(aud=temp-user) 발급 (5분 유효)

- /api/users/social/register-final
  - 임시 토큰을 인증헤더로 사용하여 추가정보(이름, 전화번호, 지역 등) 등록 후 정식 JWT 발급
- JwtAuthenticationFilter 수정
  - → /api/users/social/** 경로는 인증 예외처리 및 temp-user 식별 로직 추가

- UserService 내 로직 개선
  - → 일반 회원 중복체크 및 소셜 계정 통합

### 2. SMS 인증 기능 추가

- /api/sms/send
  - CoolSMS API 연동하여 인증번호 발송 (유효기간 5분)
- /api/sms/verify
  - 인증번호 검증 후 SmsVerificationManager에 인증 상태 저장
- 회원가입 시 인증 완료된 전화번호만 가입 가능하도록 검증 로직 추가

### 3. 예외 처리 개선
- GlobalExceptionHandler
  - 600~609, 702 등 커스텀 코드로 유효성 검사 오류 식별
  - 클라이언트에서 구체적인 오류 메시지 확인 가능

Resolves: #11 

---

## 🧾 Pull Request Type

<!-- 해당하는 항목에 체크해주세요. -->

- [x] ✨ 새로운 기능 추가
- [ ] 🐞 버그 수정
- [ ] 💄 UI/스타일 변경 (CSS 등)
- [x] 📝 코드에 영향을 주지 않는 수정 (오타, 변수명 등)
- [ ] ♻️ 코드 리팩토링
- [x] 💬 주석 추가 또는 수정
- [ ] 📚 문서 수정
- [ ] 🧪 테스트 추가 또는 리팩토링
- [ ] 🛠️ 빌드/패키지 매니저 수정
- [ ] 🗂️ 파일/폴더명 변경
- [ ] 🗑️ 파일/폴더 삭제

---

## 🧩 Additional Notes

### 테스트 시나리오 (Postman)

1️⃣ 카카오 로그인 요청 → /api/users/social/kakao
2️⃣ 임시 토큰 발급 확인 (aud=temp-user)
3️⃣ 추가정보 입력 및 회원가입 완료 → /api/users/social/register-final
4️⃣ SMS 인증 요청 → /api/sms/send
5️⃣ 인증번호 검증 성공 후 회원가입 완료
6️⃣ 로그아웃 / 재로그인 테스트 완료

### 리뷰 포인트
- [ ] 소셜 회원가입 시 임시 토큰 처리 로직 문제 없는지
- [ ] sms 인증 만료 로직 정상 동작 확인
- [ ] 회원가입 시 인증 여부 연동 정상 확인
- [ ] 예외 코드 및 메시지 구조 리뷰